### PR TITLE
feat: initial enrollment cms skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+DATABASE_URL="postgresql://user:password@localhost:5432/enrollment_cms"
+NEXTAUTH_SECRET="changeme"
+TWILIO_ACCOUNT_SID=""
+TWILIO_AUTH_TOKEN=""
+TWILIO_FROM_NUMBER=""
+SENDGRID_API_KEY=""

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["next/core-web-vitals"],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.env
+prisma/dev.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
-# open-source-cms-higher-ed
-Open Source Higher Education CMS
+# Higher Education Enrollment CMS
+
+Minimal open-source CMS for managing enrollment leads.
+
+## Setup
+
+```bash
+npm install
+npm run db:migrate
+npm run db:seed
+npm run dev
+```
+
+Requires PostgreSQL and env vars in `.env`.
+
+## Tests
+
+```bash
+npm test
+```

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,6 @@
+import NextAuth from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };

--- a/app/api/forms/[id]/submit/route.ts
+++ b/app/api/forms/[id]/submit/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/db';
+import { formSubmissionSchema } from '@/lib/validators/form';
+import { ApiError, errorResponse } from '@/lib/error';
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const json = await req.json();
+  const data = formSubmissionSchema.parse(json);
+  const form = await prisma.form.findUnique({ where: { id: params.id } });
+  if (!form) return errorResponse(new ApiError(404, 'not_found', 'Form not found'));
+  const submission = await prisma.submission.create({
+    data: {
+      formId: form.id,
+      payload: data.payload,
+      matchedBy: data.email ? 'email' : 'none'
+    }
+  });
+  if (data.email) {
+    const program = data.programOfInterestId || (await prisma.program.findFirst())?.id;
+    if (!program) throw new Error('No program configured');
+    await prisma.lead.upsert({
+      where: { email: data.email },
+      update: {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        programOfInterestId: program,
+        consentEmail: data.consentEmail ?? false,
+        consentSms: data.consentSms ?? false
+      },
+      create: {
+        firstName: data.firstName || 'Unknown',
+        lastName: data.lastName || 'Unknown',
+        email: data.email,
+        programOfInterestId: program,
+        consentEmail: data.consentEmail ?? false,
+        consentSms: data.consentSms ?? false
+      }
+    });
+  }
+  return Response.json({ id: submission.id });
+}

--- a/app/api/forms/route.ts
+++ b/app/api/forms/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, requireRole } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { ApiError, errorResponse } from '@/lib/error';
+import { createFormSchema } from '@/lib/validators/form';
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return errorResponse(new ApiError(401, 'unauthorized', 'Unauthorized'));
+  if (!requireRole(session, ['Admin'])) return errorResponse(new ApiError(403, 'forbidden', 'Forbidden'));
+  const data = createFormSchema.parse(await req.json());
+  const form = await prisma.form.create({
+    data: {
+      name: data.name,
+      slug: data.slug,
+      fields: {
+        create: data.fields.map(f => ({
+          key: f.key,
+          label: f.label,
+          type: f.type,
+          required: f.required ?? false,
+          mapToLeadField: f.mapToLeadField
+        }))
+      }
+    },
+    include: { fields: true }
+  });
+  return Response.json(form, { status: 201 });
+}

--- a/app/api/leads/[id]/route.ts
+++ b/app/api/leads/[id]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, requireRole } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { ApiError, errorResponse } from '@/lib/error';
+import { updateLeadSchema } from '@/lib/validators/lead';
+import { assertTransition } from '@/lib/stage';
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return errorResponse(new ApiError(401, 'unauthorized', 'Unauthorized'));
+  if (!requireRole(session, ['Admin', 'EnrollmentSpecialist', 'Analyst']))
+    return errorResponse(new ApiError(403, 'forbidden', 'Forbidden'));
+  const lead = await prisma.lead.findUnique({ where: { id: params.id } });
+  if (!lead) return errorResponse(new ApiError(404, 'not_found', 'Lead not found'));
+  return Response.json(lead);
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session) return errorResponse(new ApiError(401, 'unauthorized', 'Unauthorized'));
+  if (!requireRole(session, ['Admin', 'EnrollmentSpecialist']))
+    return errorResponse(new ApiError(403, 'forbidden', 'Forbidden'));
+  const json = await req.json();
+  const data = updateLeadSchema.parse(json);
+  try {
+    if (data.stage) {
+      const current = await prisma.lead.findUnique({ where: { id: params.id }, select: { stage: true } });
+      if (current && current.stage !== data.stage) assertTransition(current.stage, data.stage);
+    }
+    const lead = await prisma.lead.update({ where: { id: params.id }, data });
+    return Response.json(lead);
+  } catch (e: any) {
+    return errorResponse(new ApiError(400, 'bad_request', e.message));
+  }
+}

--- a/app/api/leads/route.ts
+++ b/app/api/leads/route.ts
@@ -1,0 +1,49 @@
+import { NextRequest } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { authOptions, requireRole } from '@/lib/auth';
+import { prisma } from '@/lib/db';
+import { ApiError, errorResponse } from '@/lib/error';
+import { createLeadSchema, leadQuerySchema } from '@/lib/validators/lead';
+import { LeadTemperature } from '@prisma/client';
+
+export async function POST(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return errorResponse(new ApiError(401, 'unauthorized', 'Unauthorized'));
+  if (!requireRole(session, ['Admin', 'EnrollmentSpecialist']))
+    return errorResponse(new ApiError(403, 'forbidden', 'Forbidden'));
+  const json = await req.json();
+  const data = createLeadSchema.parse(json);
+  try {
+    const lead = await prisma.lead.upsert({
+      where: { email: data.email },
+      update: data,
+      create: data
+    });
+    return Response.json(lead, { status: 201 });
+  } catch (e: any) {
+    return errorResponse(new ApiError(400, 'bad_request', e.message));
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const session = await getServerSession(authOptions);
+  if (!session) return errorResponse(new ApiError(401, 'unauthorized', 'Unauthorized'));
+  if (!requireRole(session, ['Admin', 'EnrollmentSpecialist', 'Analyst']))
+    return errorResponse(new ApiError(403, 'forbidden', 'Forbidden'));
+  const query = leadQuerySchema.parse(Object.fromEntries(req.nextUrl.searchParams));
+  const skip = (query.page - 1) * query.size;
+  const where = query.search
+    ? {
+        OR: [
+          { firstName: { contains: query.search, mode: 'insensitive' } },
+          { lastName: { contains: query.search, mode: 'insensitive' } },
+          { email: { contains: query.search, mode: 'insensitive' } }
+        ]
+      }
+    : {};
+  const [items, total] = await Promise.all([
+    prisma.lead.findMany({ skip, take: query.size, where, orderBy: { createdAt: 'desc' } }),
+    prisma.lead.count({ where })
+  ]);
+  return Response.json({ items, total, page: query.page, size: query.size });
+}

--- a/app/api/track/route.ts
+++ b/app/api/track/route.ts
@@ -1,0 +1,16 @@
+import { NextRequest } from 'next/server';
+import { prisma } from '@/lib/db';
+import { trackingBatchSchema } from '@/lib/validators/tracking';
+
+export async function POST(req: NextRequest) {
+  const body = await req.json();
+  const events = trackingBatchSchema.parse(body);
+  await prisma.trackingEvent.createMany({
+    data: events.map(e => ({
+      occurredAt: new Date(e.ts),
+      event: e.e,
+      meta: e.m
+    }))
+  });
+  return Response.json({ ok: true });
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+
+export default async function DashboardPage() {
+  const session = await getServerSession(authOptions);
+  return (
+    <div className="p-6">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+      <p className="mt-4">Welcome {session?.user?.name ?? 'Guest'}.</p>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,20 @@
+import './globals.css';
+import { ReactNode } from 'react';
+import { getServerSession } from 'next-auth';
+import { authOptions } from '@/lib/auth';
+import SessionProvider from '@/components/SessionProvider';
+
+export const metadata = {
+  title: 'Enrollment CMS'
+};
+
+export default async function RootLayout({ children }: { children: ReactNode }) {
+  const session = await getServerSession(authOptions);
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900">
+        <SessionProvider session={session}>{children}</SessionProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function IndexPage() {
+  redirect('/dashboard');
+}

--- a/components/SessionProvider.tsx
+++ b/components/SessionProvider.tsx
@@ -1,0 +1,8 @@
+'use client';
+
+import { SessionProvider as NextSessionProvider } from 'next-auth/react';
+import { Session } from 'next-auth';
+
+export default function SessionProvider({ children, session }: { children: React.ReactNode; session: Session | null; }) {
+  return <NextSessionProvider session={session}>{children}</NextSessionProvider>;
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,17 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './'
+});
+
+const customJestConfig = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  }
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,47 @@
+import { PrismaAdapter } from '@next-auth/prisma-adapter';
+import { NextAuthOptions } from 'next-auth';
+import CredentialsProvider from 'next-auth/providers/credentials';
+import { compare } from 'bcryptjs';
+import { prisma } from '@/lib/db';
+import { UserRole } from '@prisma/client';
+
+export const authOptions: NextAuthOptions = {
+  adapter: PrismaAdapter(prisma),
+  session: { strategy: 'jwt' },
+  providers: [
+    CredentialsProvider({
+      name: 'credentials',
+      credentials: {
+        email: { label: 'Email', type: 'text' },
+        password: { label: 'Password', type: 'password' }
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials.password) return null;
+        const user = await prisma.user.findUnique({ where: { email: credentials.email } });
+        if (!user || !user.passwordHash) return null;
+        const valid = await compare(credentials.password, user.passwordHash);
+        return valid ? { id: user.id, email: user.email, name: user.name, role: user.role } : null;
+      }
+    })
+  ],
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) {
+        token.role = (user as any).role;
+      }
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        (session.user as any).id = token.sub;
+        (session.user as any).role = token.role;
+      }
+      return session;
+    }
+  }
+};
+
+export function requireRole(session: any, roles: UserRole[]) {
+  const role = session?.user?.role as UserRole | undefined;
+  return role && roles.includes(role);
+}

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,3 @@
+import { PrismaClient } from '@prisma/client';
+
+export const prisma = new PrismaClient();

--- a/lib/encryption.ts
+++ b/lib/encryption.ts
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+
+const ALG = 'aes-256-gcm';
+const KEY = crypto.createHash('sha256').update(process.env.NEXTAUTH_SECRET || 'secret').digest();
+
+export function encrypt(text: string): { value: string; iv: string; tag: string } {
+  const iv = crypto.randomBytes(16);
+  const cipher = crypto.createCipheriv(ALG, KEY, iv);
+  const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { value: encrypted.toString('hex'), iv: iv.toString('hex'), tag: tag.toString('hex') };
+}
+
+export function decrypt(data: { value: string; iv: string; tag: string }): string {
+  const decipher = crypto.createDecipheriv(ALG, KEY, Buffer.from(data.iv, 'hex'));
+  decipher.setAuthTag(Buffer.from(data.tag, 'hex'));
+  const decrypted = Buffer.concat([decipher.update(Buffer.from(data.value, 'hex')), decipher.final()]);
+  return decrypted.toString('utf8');
+}

--- a/lib/error.ts
+++ b/lib/error.ts
@@ -1,0 +1,15 @@
+export class ApiError extends Error {
+  status: number;
+  code: string;
+  details?: unknown;
+  constructor(status: number, code: string, message: string, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function errorResponse(err: ApiError) {
+  return Response.json({ error: { code: err.code, message: err.message, details: err.details } }, { status: err.status });
+}

--- a/lib/providers/EmailProvider.ts
+++ b/lib/providers/EmailProvider.ts
@@ -1,0 +1,9 @@
+export interface EmailMessage {
+  to: string;
+  subject: string;
+  html: string;
+}
+
+export interface EmailProvider {
+  send(message: EmailMessage): Promise<string>;
+}

--- a/lib/providers/SendGridProvider.ts
+++ b/lib/providers/SendGridProvider.ts
@@ -1,0 +1,17 @@
+import sgMail from '@sendgrid/mail';
+import { EmailMessage, EmailProvider } from './EmailProvider';
+
+export class SendGridProvider implements EmailProvider {
+  constructor() {
+    sgMail.setApiKey(process.env.SENDGRID_API_KEY!);
+  }
+  async send(message: EmailMessage): Promise<string> {
+    const res = await sgMail.send({
+      to: message.to,
+      from: 'no-reply@example.com',
+      subject: message.subject,
+      html: message.html
+    });
+    return res[0].headers['x-message-id'] as string;
+  }
+}

--- a/lib/providers/SmsProvider.ts
+++ b/lib/providers/SmsProvider.ts
@@ -1,0 +1,8 @@
+export interface SmsMessage {
+  to: string;
+  body: string;
+}
+
+export interface SmsProvider {
+  send(message: SmsMessage): Promise<string>; // returns provider message id
+}

--- a/lib/providers/TwilioProvider.ts
+++ b/lib/providers/TwilioProvider.ts
@@ -1,0 +1,14 @@
+import twilio from 'twilio';
+import { SmsMessage, SmsProvider } from './SmsProvider';
+
+export class TwilioProvider implements SmsProvider {
+  private client = twilio(process.env.TWILIO_ACCOUNT_SID!, process.env.TWILIO_AUTH_TOKEN!);
+  async send(message: SmsMessage): Promise<string> {
+    const res = await this.client.messages.create({
+      to: message.to,
+      from: process.env.TWILIO_FROM_NUMBER!,
+      body: message.body
+    });
+    return res.sid;
+  }
+}

--- a/lib/stage.ts
+++ b/lib/stage.ts
@@ -1,0 +1,13 @@
+import { LeadStage } from '@prisma/client';
+
+const ORDER: LeadStage[] = ['Lead', 'Interested', 'Applied', 'Accepted', 'Deposited', 'Matriculated'];
+
+export function canTransition(from: LeadStage, to: LeadStage): boolean {
+  return ORDER.indexOf(to) - ORDER.indexOf(from) === 1;
+}
+
+export function assertTransition(from: LeadStage, to: LeadStage) {
+  if (!canTransition(from, to)) {
+    throw new Error(`Invalid stage transition from ${from} to ${to}`);
+  }
+}

--- a/lib/temperature.ts
+++ b/lib/temperature.ts
@@ -1,0 +1,40 @@
+import { LeadStage, LeadTemperature, TrackingEventType } from '@prisma/client';
+
+export interface TemperatureInput {
+  stage: LeadStage;
+  engagementScore: number; // 0-100
+  sourceQuality: number; // 0-100
+  daysSinceEngagement: number;
+}
+
+export function computeTemperature(input: TemperatureInput): LeadTemperature {
+  const stageWeight: Record<LeadStage, number> = {
+    Lead: 0,
+    Interested: 10,
+    Applied: 25,
+    Accepted: 35,
+    Deposited: 45,
+    Matriculated: 60
+  };
+
+  const score = Math.max(
+    0,
+    stageWeight[input.stage] +
+      input.engagementScore +
+      input.sourceQuality -
+      input.daysSinceEngagement * 2
+  );
+
+  if (score >= 60) return 'Hot';
+  if (score >= 25) return 'Warm';
+  return 'Cold';
+}
+
+export function temperatureFromEvents(stage: LeadStage, events: TrackingEventType[], daysSince: number): LeadTemperature {
+  let engagement = 0;
+  if (events.includes('page_view')) engagement += 10;
+  if (events.includes('form_submit')) engagement += 20;
+  if (events.includes('email_reply')) engagement += 20;
+  if (events.includes('sms_reply')) engagement += 25;
+  return computeTemperature({ stage, engagementScore: engagement, sourceQuality: 0, daysSinceEngagement: daysSince });
+}

--- a/lib/validators/form.ts
+++ b/lib/validators/form.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+export const formFieldSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  type: z.string(),
+  required: z.boolean().optional(),
+  mapToLeadField: z.string().optional()
+});
+
+export const createFormSchema = z.object({
+  name: z.string(),
+  slug: z.string(),
+  fields: z.array(formFieldSchema)
+});
+
+export const formSubmissionSchema = z.object({
+  payload: z.record(z.any()),
+  email: z.string().email().optional(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  programOfInterestId: z.string().uuid().optional(),
+  consentEmail: z.boolean().optional(),
+  consentSms: z.boolean().optional()
+});

--- a/lib/validators/lead.ts
+++ b/lib/validators/lead.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { LeadStage, LeadTemperature } from '@prisma/client';
+
+export const createLeadSchema = z.object({
+  firstName: z.string(),
+  lastName: z.string(),
+  email: z.string().email(),
+  phone: z.string().optional(),
+  programOfInterestId: z.string().uuid(),
+  stage: z.nativeEnum(LeadStage).optional(),
+  temperature: z.nativeEnum(LeadTemperature).optional(),
+  consentEmail: z.boolean(),
+  consentSms: z.boolean()
+});
+
+export const updateLeadSchema = createLeadSchema.partial();
+export const leadQuerySchema = z.object({
+  page: z.coerce.number().min(1).default(1),
+  size: z.coerce.number().min(1).max(100).default(20),
+  search: z.string().optional()
+});

--- a/lib/validators/tracking.ts
+++ b/lib/validators/tracking.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+import { TrackingEventType } from '@prisma/client';
+
+export const trackingEventSchema = z.object({
+  e: z.nativeEnum(TrackingEventType),
+  m: z.record(z.any()).optional(),
+  ts: z.number()
+});
+
+export const trackingBatchSchema = z.array(trackingEventSchema).max(50);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,7 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: "export",  // <=== enables static exports
   reactStrictMode: true,
-  experimental: {
-    appDir: true
-  }
 };
 
 module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "open-source-cms-higher-ed",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "db:migrate": "prisma migrate deploy",
+    "db:seed": "prisma db seed",
+    "test": "jest"
+  },
+  "dependencies": {
+    "@prisma/client": "5.6.0",
+    "@tanstack/react-table": "8.10.0",
+    "bcryptjs": "2.4.3",
+    "chart.js": "4.4.0",
+    "next": "14.1.0",
+    "next-auth": "5.0.0",
+    "pg": "8.11.0",
+    "react": "18.2.0",
+    "react-chartjs-2": "5.2.0",
+    "react-dom": "18.2.0",
+    "tailwindcss": "3.3.0",
+    "twilio": "4.13.0",
+    "zod": "3.22.4",
+    "@sendgrid/mail": "7.7.0",
+    "@next-auth/prisma-adapter": "1.0.6"
+  },
+  "devDependencies": {
+    "@types/bcryptjs": "2.4.2",
+    "@types/jest": "29.5.2",
+    "@types/node": "20.4.2",
+    "@types/react": "18.2.15",
+    "@types/react-dom": "18.2.7",
+    "eslint": "8.45.0",
+    "eslint-config-next": "14.1.0",
+    "jest": "29.7.0",
+    "prisma": "5.6.0",
+    "ts-jest": "29.1.1",
+    "typescript": "5.2.2",
+    "autoprefixer": "10.4.14",
+    "postcss": "8.4.31"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/prisma/migrations/000_init/migration.sql
+++ b/prisma/migrations/000_init/migration.sql
@@ -1,0 +1,139 @@
+-- Prisma migration for initial schema
+CREATE TABLE "User" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "name" TEXT,
+  "email" TEXT UNIQUE NOT NULL,
+  "passwordHash" TEXT,
+  "role" TEXT NOT NULL DEFAULT 'EnrollmentSpecialist',
+  "phone" TEXT,
+  "notificationPrefs" JSONB
+);
+
+CREATE TABLE "Program" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "name" TEXT NOT NULL,
+  "code" TEXT UNIQUE NOT NULL,
+  "school" TEXT,
+  "level" TEXT,
+  "active" BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TYPE "LeadStage" AS ENUM ('Lead','Interested','Applied','Accepted','Deposited','Matriculated');
+CREATE TYPE "LeadTemperature" AS ENUM ('Cold','Warm','Hot','Nonresponsive');
+
+CREATE TABLE "Lead" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "updatedAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "firstName" TEXT NOT NULL,
+  "lastName" TEXT NOT NULL,
+  "email" TEXT UNIQUE NOT NULL,
+  "phone" TEXT,
+  "street" TEXT,
+  "city" TEXT,
+  "state" TEXT,
+  "postal" TEXT,
+  "country" TEXT,
+  "programOfInterestId" UUID NOT NULL REFERENCES "Program"("id"),
+  "birthDate" DATE,
+  "stage" "LeadStage" NOT NULL DEFAULT 'Lead',
+  "temperature" "LeadTemperature" NOT NULL DEFAULT 'Cold',
+  "ownerId" UUID REFERENCES "User"("id"),
+  "consentEmail" BOOLEAN NOT NULL,
+  "consentSms" BOOLEAN NOT NULL,
+  "privacyAcceptedAt" TIMESTAMP,
+  "utmSource" TEXT,
+  "utmMedium" TEXT,
+  "utmCampaign" TEXT,
+  "utmContent" TEXT,
+  "utmTerm" TEXT,
+  "referrer" TEXT,
+  "firstTouchAt" TIMESTAMP,
+  "lastTouchAt" TIMESTAMP
+);
+
+CREATE TYPE "CommunicationType" AS ENUM ('sms','email');
+CREATE TYPE "CommunicationDirection" AS ENUM ('out','in');
+CREATE TYPE "CommunicationStatus" AS ENUM ('queued','sent','delivered','failed','bounced');
+CREATE TABLE "Communication" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "leadId" UUID NOT NULL REFERENCES "Lead"("id"),
+  "userId" UUID REFERENCES "User"("id"),
+  "type" "CommunicationType" NOT NULL,
+  "direction" "CommunicationDirection" NOT NULL,
+  "status" "CommunicationStatus" NOT NULL,
+  "subject" TEXT,
+  "body" TEXT,
+  "providerMessageId" TEXT,
+  "sentAt" TIMESTAMP,
+  "error" TEXT,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW()
+);
+
+CREATE TYPE "FormStatus" AS ENUM ('draft','published');
+CREATE TABLE "Form" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "name" TEXT NOT NULL,
+  "slug" TEXT UNIQUE NOT NULL,
+  "status" "FormStatus" NOT NULL DEFAULT 'draft',
+  "embedScript" TEXT,
+  "createdById" UUID REFERENCES "User"("id")
+);
+
+CREATE TABLE "FormField" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "formId" UUID NOT NULL REFERENCES "Form"("id"),
+  "key" TEXT NOT NULL,
+  "label" TEXT NOT NULL,
+  "type" TEXT NOT NULL,
+  "required" BOOLEAN NOT NULL DEFAULT FALSE,
+  "options" JSONB,
+  "mapToLeadField" TEXT
+);
+
+CREATE TABLE "Submission" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "formId" UUID NOT NULL REFERENCES "Form"("id"),
+  "payload" JSONB NOT NULL,
+  "createdAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "leadId" UUID REFERENCES "Lead"("id"),
+  "matchedBy" TEXT
+);
+
+CREATE TYPE "TrackingEventType" AS ENUM ('page_view','form_view','form_submit','email_open','sms_click','email_reply','sms_reply','custom');
+CREATE TABLE "TrackingEvent" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "occurredAt" TIMESTAMP NOT NULL,
+  "event" "TrackingEventType" NOT NULL,
+  "meta" JSONB,
+  "sessionId" TEXT,
+  "leadId" UUID REFERENCES "Lead"("id")
+);
+
+CREATE TABLE "Report" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "name" TEXT NOT NULL,
+  "ownerId" UUID REFERENCES "User"("id"),
+  "filters" JSONB,
+  "columns" JSONB,
+  "sorts" JSONB,
+  "shared" BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE "AuditLog" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "occurredAt" TIMESTAMP NOT NULL DEFAULT NOW(),
+  "userId" UUID REFERENCES "User"("id"),
+  "entity" TEXT NOT NULL,
+  "entityId" TEXT NOT NULL,
+  "action" TEXT NOT NULL,
+  "diff" JSONB
+);
+
+CREATE TABLE "Config" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "key" TEXT UNIQUE NOT NULL,
+  "value" JSONB
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,214 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum UserRole {
+  Admin
+  Analyst
+  EnrollmentSpecialist
+}
+
+enum LeadStage {
+  Lead
+  Interested
+  Applied
+  Accepted
+  Deposited
+  Matriculated
+}
+
+enum LeadTemperature {
+  Cold
+  Warm
+  Hot
+  Nonresponsive
+}
+
+enum TrackingEventType {
+  page_view
+  form_view
+  form_submit
+  email_open
+  sms_click
+  email_reply
+  sms_reply
+  custom
+}
+
+enum CommunicationType {
+  sms
+  email
+}
+
+enum CommunicationDirection {
+  out
+  in
+}
+
+enum CommunicationStatus {
+  queued
+  sent
+  delivered
+  failed
+  bounced
+}
+
+enum FormStatus {
+  draft
+  published
+}
+
+model User {
+  id               String   @id @default(uuid())
+  createdAt        DateTime @default(now())
+  updatedAt        DateTime @updatedAt
+  name             String?
+  email            String   @unique
+  passwordHash     String?
+  role             UserRole @default(EnrollmentSpecialist)
+  phone            String?
+  notificationPrefs Json?
+  leads            Lead[]   @relation("LeadOwner")
+  auditLogs        AuditLog[]
+}
+
+model Program {
+  id      String  @id @default(uuid())
+  name    String
+  code    String  @unique
+  school  String?
+  level   String?
+  active  Boolean @default(true)
+  leads   Lead[]
+}
+
+model Lead {
+  id        String   @id @default(uuid())
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  firstName String
+  lastName  String
+  email     String   @unique
+  phone     String?
+  street    String?
+  city      String?
+  state     String?
+  postal    String?
+  country   String?
+  programOfInterestId String
+  program   Program  @relation(fields: [programOfInterestId], references: [id])
+  birthDate DateTime?
+  stage     LeadStage @default(Lead)
+  temperature LeadTemperature @default(Cold)
+  ownerId   String?
+  owner     User?    @relation("LeadOwner", fields: [ownerId], references: [id])
+  consentEmail Boolean
+  consentSms   Boolean
+  privacyAcceptedAt DateTime?
+  utmSource  String?
+  utmMedium  String?
+  utmCampaign String?
+  utmContent String?
+  utmTerm    String?
+  referrer   String?
+  firstTouchAt DateTime?
+  lastTouchAt  DateTime?
+  communications Communication[]
+  trackingEvents TrackingEvent[]
+  submissions Submission[]
+}
+
+model Communication {
+  id        String   @id @default(uuid())
+  leadId    String
+  lead      Lead     @relation(fields: [leadId], references: [id])
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  type      CommunicationType
+  direction CommunicationDirection
+  status    CommunicationStatus
+  subject   String?
+  body      String?
+  providerMessageId String?
+  sentAt    DateTime?
+  error     String?
+  createdAt DateTime @default(now())
+}
+
+model Form {
+  id          String   @id @default(uuid())
+  name        String
+  slug        String   @unique
+  status      FormStatus @default(draft)
+  embedScript String?
+  createdById String?
+  createdBy   User?     @relation(fields: [createdById], references: [id])
+  fields      FormField[]
+  submissions Submission[]
+}
+
+model FormField {
+  id        String   @id @default(uuid())
+  formId    String
+  form      Form     @relation(fields: [formId], references: [id])
+  key       String
+  label     String
+  type      String
+  required  Boolean @default(false)
+  options   Json?
+  mapToLeadField String?
+}
+
+model Submission {
+  id        String   @id @default(uuid())
+  formId    String
+  form      Form     @relation(fields: [formId], references: [id])
+  payload   Json
+  createdAt DateTime @default(now())
+  leadId    String?
+  matchedBy String?
+  lead      Lead?    @relation(fields: [leadId], references: [id])
+}
+
+model TrackingEvent {
+  id        String   @id @default(uuid())
+  occurredAt DateTime
+  event     TrackingEventType
+  meta      Json?
+  sessionId String?
+  leadId    String?
+  lead      Lead?    @relation(fields: [leadId], references: [id])
+}
+
+model Report {
+  id       String @id @default(uuid())
+  name     String
+  ownerId  String?
+  owner    User? @relation(fields: [ownerId], references: [id])
+  filters  Json?
+  columns  Json?
+  sorts    Json?
+  shared   Boolean @default(false)
+}
+
+model AuditLog {
+  id        String   @id @default(uuid())
+  occurredAt DateTime @default(now())
+  userId    String?
+  user      User?    @relation(fields: [userId], references: [id])
+  entity    String
+  entityId  String
+  action    String
+  diff      Json?
+}
+
+model Config {
+  id    String @id @default(uuid())
+  key   String @unique
+  value Json?
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,58 @@
+import { prisma } from '../lib/db';
+import { hash } from 'bcryptjs';
+import { LeadStage, LeadTemperature } from '@prisma/client';
+
+async function main() {
+  const programs = await prisma.program.createMany({
+    data: Array.from({ length: 5 }).map((_, i) => ({
+      name: `Program ${i + 1}`,
+      code: `P${i + 1}`
+    }))
+  });
+
+  const admin = await prisma.user.create({
+    data: {
+      email: 'admin@example.com',
+      role: 'Admin',
+      passwordHash: await hash('password', 10)
+    }
+  });
+
+  const specialists = await Promise.all(
+    Array.from({ length: 3 }).map((_, i) =>
+      prisma.user.create({
+        data: {
+          email: `spec${i + 1}@example.com`,
+          role: 'EnrollmentSpecialist',
+          passwordHash: await hash('password', 10)
+        }
+      })
+    )
+  );
+
+  const programIds = (await prisma.program.findMany()).map(p => p.id);
+  const specialistIds = specialists.map(s => s.id);
+
+  for (let i = 0; i < 20; i++) {
+    await prisma.lead.create({
+      data: {
+        firstName: `Lead${i}`,
+        lastName: 'Test',
+        email: `lead${i}@example.com`,
+        programOfInterestId: programIds[i % programIds.length],
+        stage: Object.values(LeadStage)[i % Object.values(LeadStage).length],
+        temperature: Object.values(LeadTemperature)[i % Object.values(LeadTemperature).length],
+        consentEmail: true,
+        consentSms: true,
+        ownerId: specialistIds[i % specialistIds.length]
+      }
+    });
+  }
+
+  console.log('Seed complete');
+}
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,21 @@
+import { POST } from '../app/api/forms/[id]/submit/route';
+
+jest.mock('../lib/db', () => ({
+  prisma: {
+    form: { findUnique: jest.fn().mockResolvedValue({ id: 'form1' }) },
+    submission: { create: jest.fn().mockResolvedValue({ id: 'sub1' }) },
+    program: { findFirst: jest.fn().mockResolvedValue({ id: 'prog1' }) },
+    lead: { upsert: jest.fn().mockResolvedValue({}) }
+  }
+}));
+
+test('form submission creates lead', async () => {
+  const req = new Request('http://test', {
+    method: 'POST',
+    body: JSON.stringify({ payload: {}, email: 'a@test.com', consentEmail: true, consentSms: true }),
+    headers: { 'Content-Type': 'application/json' }
+  }) as any;
+  const res = await POST(req, { params: { id: 'form1' } });
+  const json = await res.json();
+  expect(json.id).toBe('sub1');
+});

--- a/tests/stage.test.ts
+++ b/tests/stage.test.ts
@@ -1,0 +1,10 @@
+import { canTransition } from '../lib/stage';
+import { LeadStage } from '@prisma/client';
+
+test('valid transition', () => {
+  expect(canTransition(LeadStage.Lead, LeadStage.Interested)).toBe(true);
+});
+
+test('invalid transition', () => {
+  expect(canTransition(LeadStage.Lead, LeadStage.Accepted)).toBe(false);
+});

--- a/tests/temperature.test.ts
+++ b/tests/temperature.test.ts
@@ -1,0 +1,7 @@
+import { computeTemperature } from '../lib/temperature';
+import { LeadStage } from '@prisma/client';
+
+test('temperature calculation', () => {
+  const temp = computeTemperature({ stage: LeadStage.Applied, engagementScore: 20, sourceQuality: 10, daysSinceEngagement: 1 });
+  expect(temp).toBe('Warm');
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ES2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["jest", "node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold Next.js 14 app with NextAuth, Tailwind and Prisma
- add core models (Lead, Program, Form, Submission, TrackingEvent, etc.) and seed script
- implement basic REST routes for leads, forms, and tracking with Zod validation and RBAC
- include utility modules, messaging providers, and minimal tests

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@next-auth%2fprisma-adapter)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896ad107f2c832dad9092b852c0fe88